### PR TITLE
Add pages UI

### DIFF
--- a/cypress/integration/main.test.js
+++ b/cypress/integration/main.test.js
@@ -9,66 +9,77 @@ describe('Main', () => {
     cy.wait(500);
   });
 
-  it('sets a default name', () => {
-    cy.get('input[name=name]').should('have.value', 'No name set');
-  });
-
-  it('returns an error if no room exists', () => {
-    cy.get('input[name=gameId]').type('ABCD').should('have.value', 'ABCD');
-
-    cy.get('#join-game-button').click();
-
-    cy.get('#error-display').should('contain', 'Error: game does not exist');
-  });
-
-  it('creates a room', () => {
-    cy.get('#create-game-button').click();
-
-    cy.get('#game-id-display')
-      .invoke('text')
-      .should('match', /Game ID: [a-z0-9]{4}/);
-
-    cy.get('input[name=gameId]')
-      .invoke('val')
-      .should('match', /[a-z0-9]{4}/);
-
-    cy.get('#player-list-display').should('contain', 'No name set');
-  });
-
-  it('joins an existing room', () => {
-    cy.get('#create-game-button').click();
-
-    cy.get('#join-game-button').click();
-
-    cy.get('#game-id-display')
-      .invoke('text')
-      .should('match', /Game ID: [a-z0-9]{4}/);
-
-    cy.get('input[name=gameId]')
-      .invoke('val')
-      .should('match', /[a-z0-9]{4}/);
-
-    cy.get('#player-list-display').should('contain', 'No name set');
-  });
-
-  it('leaves a room', () => {
-    cy.get('#create-game-button').click();
-
-    cy.get('#leave-game-button').click();
-
-    cy.get('#game-id-display').should('contain', 'Game ID: ');
-
-    cy.get('input[name=gameId]').should('be.empty');
+  it('does not set a default name', () => {
+    cy.get('input[name=name]').should('have.value', '');
   });
 
   it('sets name', () => {
     cy.get('input[name=name]').clear();
     cy.get('input[name=name]').type('wz');
-
     cy.get('#set-name-button').click();
+
+    cy.get('#name-display').should('contain', 'wz');
 
     cy.visit('/');
 
-    cy.get('input[name=name]').should('have.value', 'wz');
+    cy.get('#name-display').should('contain', 'wz');
+  });
+
+  describe('with name set', () => {
+    beforeEach(() => {
+      cy.get('input[name=name]').clear();
+      cy.get('input[name=name]').type('wz');
+      cy.get('#set-name-button').click();
+    });
+
+    it('returns an error if no room exists', () => {
+      cy.get('input[name=gameId]').type('ABCD').should('have.value', 'ABCD');
+
+      cy.get('#join-game-button').click();
+
+      cy.get('#error-display').should('contain', 'Error: game does not exist');
+    });
+
+    it('interaction with rooms', () => {
+      cy.get('#create-game-button').click();
+
+      const regex = /Game ID: ([a-z0-9]{4})/;
+
+      cy.get('#game-id-display').invoke('text').should('match', regex);
+      cy.get('#player-list-display').should('contain', 'wz');
+
+      // leave game and re-join
+      cy.get('#game-id-display')
+        .invoke('text')
+        .then((val) => {
+          // save ID from current room
+          const id = val.match(regex)[1];
+
+          cy.get('#leave-game-button').click();
+
+          cy.get('input[name=gameId]').should('be.empty');
+
+          cy.get('input[name=gameId]').type(id);
+
+          cy.get('#join-game-button').click();
+
+          cy.get('#game-id-display').invoke('text').should('match', regex);
+          cy.get('#player-list-display').should('contain', 'wz');
+        });
+    });
+
+    describe('in waiting room', () => {
+      beforeEach(() => {
+        cy.get('#create-game-button').click();
+      });
+
+      it('starts the game', () => {
+        cy.get('#start-game-button').click();
+
+        cy.get('#prompt-display')
+          .invoke('text')
+          .should('match', /Random prompt:/);
+      });
+    });
   });
 });

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -19,7 +19,7 @@
     <div id="app" v-cloak>
       <b-container>
         <b-alert show variant="success" v-if="page !== 'set-name'">
-          <span>{{ state.name }}</span>
+          <span id="name-display">{{ state.name }}</span>
           <b-button v-on:click="editName = true" v-if="page !== 'ingame'">Edit name</b-button>
         </b-alert>
         <template id="page-set-name" v-else>
@@ -38,10 +38,10 @@
         <template id="page-waiting" v-else-if="page === 'waiting'">
           <b-alert id="game-id-display" show>Game ID: {{ state.gameId }}</b-alert>
           <b-alert id="player-list-display" show>Players: {{ state.playerList }}</b-alert>
-          <b-button v-on:click="startGame">Everybody's in!</b-button>
+          <b-button id="start-game-button" v-on:click="startGame">Everybody's in!</b-button>
         </template>
         <template id="page-ingame" v-else-if="page === 'ingame'">
-          <b-alert show>Random prompt: {{ state.prompt }}</b-alert>
+          <b-alert id="prompt-display" show>Random prompt: {{ state.prompt }}</b-alert>
           <canvas ref="easel" width="500" height="500"></canvas>
           <b-button id="post" v-on:click="postDrawing" variant="success">post</b-button>
           <h2>Feed</h2>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -45,12 +45,7 @@
           <canvas ref="easel" width="500" height="500"></canvas>
           <b-button id="post" v-on:click="postDrawing" variant="success">post</b-button>
           <h2>Feed</h2>
-          <div
-            id="feed-container"
-            ref="gallery"
-            class="canvas-container"
-            style="width: 500px; height: 500px; user-select: none"
-          ></div>
+          <canvas ref="gallery" width="500" height="500"></canvas>
         </template>
         <b-alert id="error-display" show fade v-if="state.errorMessage" variant="danger"
           >Error: {{ state.errorMessage }}</b-alert

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -51,7 +51,9 @@
             style="width: 500px; height: 500px; user-select: none"
           ></div>
         </template>
-        <b-alert id="error-display" v-model="state.errorMessage">Error: {{ state.errorMessage }}</b-alert>
+        <b-alert id="error-display" show v-if="state.errorMessage" variant="danger"
+          >Error: {{ state.errorMessage }}</b-alert
+        >
         <b-button id="leave-game-button" v-if="state.gameId" v-on:click="leaveGame" variant="danger"
           >Leave game</b-button
         >

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -16,34 +16,46 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/fabric.js/4.2.0/fabric.min.js"></script>
   </head>
   <body>
-    <div id="app">
-      <b-container id="page-set-name">
-        <b-form-group label="Name">
-          <b-form-input name="name" v-model="name"></b-form-input>
-        </b-form-group>
-        <b-button id="set-name-button" v-on:click="setName" variant="primary">Set name</b-button>
-      </b-container>
-      <b-container id="page-landing" v-if="page === 'landing'">
-        <b-form-group label="Game ID">
-          <b-form-input name="gameId" v-model="gameId"></b-form-input>
+    <div id="app" v-cloak>
+      <b-container>
+        <b-alert show variant="success" v-if="page !== 'set-name'">
+          <span>{{ state.name }}</span>
+          <b-button v-on:click="toggleEditName" v-if="page !== 'ingame'">Edit name</b-button>
+        </b-alert>
+        <template id="page-set-name" v-else>
+          <b-form-group label="Name">
+            <b-form-input name="name" v-model="state.name"></b-form-input>
+          </b-form-group>
+          <b-button id="set-name-button" v-on:click="setName" variant="primary">Set name</b-button>
+        </template>
+        <template id="page-landing" v-if="page === 'landing'">
+          <b-form-group label="Game ID">
+            <b-form-input name="gameId" v-model="state.gameId"></b-form-input>
+          </b-form-group>
           <b-button id="join-game-button" v-on:click="joinGame" variant="success">Join game</b-button>
           <b-button id="create-game-button" v-on:click="createGame" variant="info"> Create game </b-button>
-        </b-form-group>
+        </template>
+        <template id="page-waiting" v-else-if="page === 'waiting'">
+          <b-alert id="game-id-display" show>Game ID: {{ state.gameId }}</b-alert>
+          <b-alert id="player-list-display" show>Players: {{ state.playerList }}</b-alert>
+          <b-button v-on:click="startGame">Everybody's in!</b-button>
+        </template>
+        <template id="page-ingame" v-else-if="page === 'ingame'">
+          <b-alert show>Random prompt: {{ state.prompt }}</b-alert>
+          <canvas ref="easel" width="500" height="500"></canvas>
+          <b-button id="post" v-on:click="postDrawing" variant="success">post</b-button>
+          <h2>Feed</h2>
+          <div
+            id="feed-container"
+            class="canvas-container"
+            style="width: 500px; height: 500px; user-select: none"
+          ></div>
+        </template>
+        <b-alert id="error-display" v-model="state.errorMessage">Error: {{ state.errorMessage }}</b-alert>
+        <b-button id="leave-game-button" v-if="state.gameId" v-on:click="leaveGame" variant="danger"
+          >Leave game</b-button
+        >
       </b-container>
-      <b-container id="page-waiting" v-else-if="page === 'waiting'">
-        <b-alert id="game-id-display" show>Game ID: {{ gameId }}</b-alert>
-        <b-alert id="player-list-display" show>Players: {{playerList}}</b-alert>
-        <b-button v-on:click="startGame">Everybody's in!</b-button>
-      </b-container>
-      <b-container id="page-ingame" v-else-if="page === 'ingame'">
-        <b-alert show>Random prompt: {{ prompt }}</b-alert>
-        <canvas ref="easel" width="500" height="500"></canvas>
-        <b-button id="post" v-on:click="postDrawing" variant="success">post</b-button>
-        <h2>Feed</h2>
-        <div id="feed-container" class="canvas-container" style="width: 500px; height: 500px; user-select: none"></div>
-      </b-container>
-      <b-alert id="error-display" v-model="errorMessage">Error: {{ errorMessage }}</b-alert>
-      <b-button id="leave-game-button" v-if="gameId" v-on:click="leaveGame" variant="danger">Leave game</b-button>
     </div>
 
     <script src="main.js"></script>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -24,13 +24,13 @@
         </b-alert>
         <template id="page-set-name" v-else>
           <b-form-group label="Name">
-            <b-form-input name="name" v-model="state.name"></b-form-input>
+            <b-form-input name="name" v-model="localState.name"></b-form-input>
           </b-form-group>
           <b-button id="set-name-button" v-on:click="setName" variant="primary">Set name</b-button>
         </template>
         <template id="page-landing" v-if="page === 'landing'">
           <b-form-group label="Game ID">
-            <b-form-input name="gameId" v-model="state.gameId"></b-form-input>
+            <b-form-input name="gameId" v-model="localState.gameId"></b-form-input>
           </b-form-group>
           <b-button id="join-game-button" v-on:click="joinGame" variant="success">Join game</b-button>
           <b-button id="create-game-button" v-on:click="createGame" variant="info"> Create game </b-button>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -6,56 +6,44 @@
     <link href="/main.css" rel="stylesheet" />
     <link type="text/css" rel="stylesheet" href="//unpkg.com/bootstrap/dist/css/bootstrap.min.css" />
     <link type="text/css" rel="stylesheet" href="//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.min.css" />
-    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
     <script src="//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.min.js"></script>
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.1/socket.io.js"
+      src="//cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.1/socket.io.js"
       integrity="sha512-AcZyhRP/tbAEsXCCGlziPun5iFvcSUpEz2jKkx0blkYKbxU81F+iq8FURwPn1sYFeksJ+sDDrI5XujsqSobWdQ=="
       crossorigin="anonymous"
     ></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/4.2.0/fabric.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/fabric.js/4.2.0/fabric.min.js"></script>
   </head>
   <body>
     <div id="app">
-      <b-container>
+      <b-container id="page-set-name">
+        <b-form-group label="Name">
+          <b-form-input name="name" v-model="name"></b-form-input>
+        </b-form-group>
+        <b-button id="set-name-button" v-on:click="setName" variant="primary">Set name</b-button>
+      </b-container>
+      <b-container id="page-landing" v-if="page === 'landing'">
+        <b-form-group label="Game ID">
+          <b-form-input name="gameId" v-model="gameId"></b-form-input>
+          <b-button id="join-game-button" v-on:click="joinGame" variant="success">Join game</b-button>
+          <b-button id="create-game-button" v-on:click="createGame" variant="info"> Create game </b-button>
+        </b-form-group>
+      </b-container>
+      <b-container id="page-waiting" v-else-if="page === 'waiting'">
         <b-alert id="game-id-display" show>Game ID: {{ gameId }}</b-alert>
         <b-alert id="player-list-display" show>Players: {{playerList}}</b-alert>
-      </b-container>
-      <b-container>
-        <b-form-group label="Name">
-          <b-form-input name="name" v-model="name" class="editable-field"></b-form-input>
-          <b-button id="set-name-button" v-on:click="setName">Set name</b-button>
-        </b-form-group>
-        <b-form-group label="Game ID">
-          <b-form-input name="gameId" v-model="gameId" class="editable-field"></b-form-input>
-          <b-button id="join-game-button" v-on:click="joinGame">Join game</b-button>
-        </b-form-group>
-        <b-button id="create-game-button" v-on:click="createGame"> Create game </b-button>
-        <b-button id="leave-game-button" v-on:click="leaveGame"> Leave game </b-button>
         <b-button v-on:click="startGame">Everybody's in!</b-button>
+      </b-container>
+      <b-container id="page-ingame" v-else-if="page === 'ingame'">
         <b-alert show>Random prompt: {{ prompt }}</b-alert>
-        <b-alert id="error-display" show>Error: {{ errorMessage }}</b-alert>
-        <div class="canvas-container" style="width: 500px; height: 500px; position: relative; user-select: none">
-          <canvas
-            id="c"
-            width="500"
-            height="500"
-            style="
-              border: 1px solid rgb(170, 170, 170);
-              position: absolute;
-              width: 500px;
-              height: 500px;
-              left: 0px;
-              top: 0px;
-              touch-action: none;
-              user-select: none;
-            "
-          ></canvas>
-        </div>
-        <b-button id="post" v-on:click="postDrawing">post</b-button>
+        <canvas ref="easel" width="500" height="500"></canvas>
+        <b-button id="post" v-on:click="postDrawing" variant="success">post</b-button>
         <h2>Feed</h2>
         <div id="feed-container" class="canvas-container" style="width: 500px; height: 500px; user-select: none"></div>
       </b-container>
+      <b-alert id="error-display" v-model="errorMessage">Error: {{ errorMessage }}</b-alert>
+      <b-button id="leave-game-button" v-if="gameId" v-on:click="leaveGame" variant="danger">Leave game</b-button>
     </div>
 
     <script src="main.js"></script>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -20,7 +20,7 @@
       <b-container>
         <b-alert show variant="success" v-if="page !== 'set-name'">
           <span>{{ state.name }}</span>
-          <b-button v-on:click="toggleEditName" v-if="page !== 'ingame'">Edit name</b-button>
+          <b-button v-on:click="editName = true" v-if="page !== 'ingame'">Edit name</b-button>
         </b-alert>
         <template id="page-set-name" v-else>
           <b-form-group label="Name">
@@ -47,11 +47,12 @@
           <h2>Feed</h2>
           <div
             id="feed-container"
+            ref="gallery"
             class="canvas-container"
             style="width: 500px; height: 500px; user-select: none"
           ></div>
         </template>
-        <b-alert id="error-display" show v-if="state.errorMessage" variant="danger"
+        <b-alert id="error-display" show fade v-if="state.errorMessage" variant="danger"
           >Error: {{ state.errorMessage }}</b-alert
         >
         <b-button id="leave-game-button" v-if="state.gameId" v-on:click="leaveGame" variant="danger"

--- a/src/client/main.css
+++ b/src/client/main.css
@@ -1,3 +1,5 @@
-.editable-field {
-  outline: none;
+.canvas-container {
+  border: 1px solid rgb(170, 170, 170);
+  position: relative;
+  user-select: none;
 }

--- a/src/client/main.css
+++ b/src/client/main.css
@@ -1,3 +1,7 @@
+[v-cloak] {
+  display: none;
+}
+
 .canvas-container {
   border: 1px solid rgb(170, 170, 170);
   position: relative;

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -45,20 +45,8 @@ const app = new Vue({
       if (!viewDrawing || !ref) {
         return;
       }
-      const c = document.createElement('canvas');
-      c.width = '500';
-      c.height = '500';
-      c.style = `border: 1px solid rgb(170, 170, 170);
-          width: 500px;
-          height: 500px;
-          touch-action: none;
-          user-select: none;`;
-      c.id =
-        Math.random().toString(36).substring(2, 15) +
-        Math.random().toString(36).substring(2, 15);
-      ref.appendChild(c);
 
-      const drawing = new fabric.Canvas(c);
+      const drawing = new fabric.Canvas(ref);
       drawing.loadFromJSON(viewDrawing);
     },
   },

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -16,6 +16,10 @@ const app = new Vue({
       },
       // local client state
       editName: true,
+      localState: {
+        name: '',
+        gameId: '',
+      },
     };
   },
   computed: {
@@ -57,13 +61,13 @@ const app = new Vue({
       socket.emit('create-game');
     },
     joinGame() {
-      socket.emit('join-game', this.state.gameId);
+      socket.emit('join-game', this.localState.gameId);
     },
     leaveGame() {
       socket.emit('leave-game');
     },
     setName() {
-      const { name } = this.state;
+      const { name } = this.localState;
       if (!name.length) {
         return;
       }
@@ -96,4 +100,7 @@ socket.on('sync', (data) => {
   Object.entries(data).forEach(([key, val]) => {
     app.state[key] = val;
   });
+  if (app.state.name) {
+    app.localState.name = app.state.name;
+  }
 });

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -15,7 +15,7 @@ const app = new Vue({
         viewDrawing: null,
       },
       // local client state
-      editName: true,
+      editName: false,
       localState: {
         name: '',
         gameId: '',
@@ -38,7 +38,13 @@ const app = new Vue({
     },
   },
   watch: {
-    viewDrawing(newDrawing) {
+    state(newState) {
+      console.log({ newState });
+      const { viewDrawing } = newState;
+      const ref = this.$refs.gallery;
+      if (!viewDrawing || !ref) {
+        return;
+      }
       const c = document.createElement('canvas');
       c.width = '500';
       c.height = '500';
@@ -50,10 +56,10 @@ const app = new Vue({
       c.id =
         Math.random().toString(36).substring(2, 15) +
         Math.random().toString(36).substring(2, 15);
-      document.querySelector('#feed-container').appendChild(c);
+      ref.appendChild(c);
 
-      const drawing = new fabric.Canvas(c.id);
-      drawing.loadFromJSON(newDrawing);
+      const drawing = new fabric.Canvas(c);
+      drawing.loadFromJSON(viewDrawing);
     },
   },
   methods: {
@@ -72,16 +78,13 @@ const app = new Vue({
         return;
       }
       socket.emit('set-name', name);
-      this.toggleEditName();
+      this.editName = false;
     },
     startGame() {
       socket.emit('start-game');
     },
     postDrawing() {
       socket.emit('post-drawing', JSON.stringify(canvas));
-    },
-    toggleEditName() {
-      this.editName = !this.editName;
     },
   },
   updated() {
@@ -97,9 +100,7 @@ const app = new Vue({
 });
 
 socket.on('sync', (data) => {
-  Object.entries(data).forEach(([key, val]) => {
-    app.state[key] = val;
-  });
+  app.state = data;
   if (app.state.name) {
     app.localState.name = app.state.name;
   }

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -1,14 +1,12 @@
 const socket = io();
 
-const canvas = new fabric.Canvas('c', {
-  isDrawingMode: true,
-});
-canvas.freeDrawingBrush.width = 10;
+let canvas;
 
 const app = new Vue({
   el: '#app',
   data() {
     return {
+      page: '',
       name: '',
       gameId: '',
       prompt: '',
@@ -19,7 +17,6 @@ const app = new Vue({
   },
   watch: {
     viewDrawing(newDrawing) {
-      console.log('displaying drawing');
       const c = document.createElement('canvas');
       c.width = '500';
       c.height = '500';
@@ -57,10 +54,29 @@ const app = new Vue({
       socket.emit('post-drawing', JSON.stringify(canvas));
     },
   },
+  updated() {
+    const ref = this.$refs.easel;
+    if (ref) {
+      canvas = new fabric.Canvas(ref, {
+        isDrawingMode: true,
+      });
+      canvas.freeDrawingBrush.color = 'purple';
+      canvas.freeDrawingBrush.width = 10;
+    }
+  },
 });
 
 socket.on('sync', (data) => {
   Object.entries(data).forEach(([key, val]) => {
     app[key] = val;
   });
+  if (app.gameId) {
+    if (app.prompt) {
+      app.page = 'ingame';
+    } else {
+      app.page = 'waiting';
+    }
+  } else {
+    app.page = 'landing';
+  }
 });

--- a/src/server/game.js
+++ b/src/server/game.js
@@ -65,6 +65,10 @@ export class Game {
     this.players.push(player);
   }
 
+  removePlayer(player) {
+    this.players = this.players.filter((p) => p !== player);
+  }
+
   // output a list of all the players in the specified game
   listPlayers() {
     return this.players.map((player) => player.getName()).join(', ');

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -57,7 +57,7 @@ io.on('connect', (socket) => {
   socket.on('join-game', (gameId) => {
     const game = mgr.getGame(gameId);
     if (!game) {
-      player.setError('game does not exist');
+      player.sendError('game does not exist');
       return;
     }
 

--- a/src/server/player.js
+++ b/src/server/player.js
@@ -7,7 +7,7 @@ export class Player {
     this.log = createLogger(this.id);
     this.game = null;
     this.state = {
-      name: 'No name set',
+      name: '',
       errorMessage: null,
       prompt: null,
       viewDrawing: null,

--- a/src/server/player.js
+++ b/src/server/player.js
@@ -51,9 +51,10 @@ export class Player {
     }
   }
 
-  setError(err) {
+  sendError(err) {
     this.state.errorMessage = err;
     this.sync();
+    this.state.errorMessage = null;
   }
 
   setPrompt(prompt) {
@@ -89,7 +90,7 @@ export class Player {
 
   emit(tag, message) {
     this.socket.emit(tag, message);
-    this.log(`sending player ${this.id.substring(1, 6)} the message ${tag}:`);
+    this.log(`emit [${tag}]:`);
 
     // remove viewDrawing because it's too big
     const strippedMessage = {

--- a/src/server/player.js
+++ b/src/server/player.js
@@ -32,7 +32,7 @@ export class Player {
     if (this.game) {
       return this.game.id;
     }
-    return undefined;
+    return null;
   }
 
   joinGame(game) {
@@ -45,6 +45,7 @@ export class Player {
 
   leaveGame() {
     if (this.game) {
+      this.game.removePlayer(this);
       this.game = null;
       this.update();
     }

--- a/src/server/player.test.js
+++ b/src/server/player.test.js
@@ -7,11 +7,11 @@ test('should send message to socket', () => {
   };
   player.setSocket(mockSocket);
   expect(mockSocket.emit).toHaveBeenCalledWith('sync', {
-    name: 'No name set',
+    name: '',
     errorMessage: null,
     prompt: null,
     viewDrawing: null,
-    gameId: undefined,
+    gameId: null,
     playerList: null,
   });
 });


### PR DESCRIPTION
Splits the UI up into separate pages, there are now different screens for:
- updating the player name
- landing page - options to create or join a game
- waiting room - player can see the current game ID and all other connected players
- ingame - player sees their prompt and can submit a drawing

Fixed a few bugs related to:
- leaving the game
- error messages persisting between page refreshes